### PR TITLE
This pull request adds the OdeCoin jetton metadata file to the `jettons` directory.

### DIFF
--- a/jettons/EQAZx6cklgrhMUTVVtWyYz16zaW--bH6QnJo-wjJvkb-1ab9.yaml
+++ b/jettons/EQAZx6cklgrhMUTVVtWyYz16zaW--bH6QnJo-wjJvkb-1ab9.yaml
@@ -1,0 +1,10 @@
+name: OdeCoin
+description: Utility token for the OdeCloud ecosystem — powering rewards, perks, and community engagement.
+image: "https://raw.githubusercontent.com/odecloud/odecoin-assets/main/logo.png"
+address: EQAZx6cklgrhMUTVVtWyYz16zaW--bH6QnJo-wjJvkb-1ab9
+symbol: ODE
+websites:
+- "https://odecloud.com"
+social:
+  - "https://www.linkedin.com/company/odecloud"
+  - "https://www.instagram.com/odecloud/"


### PR DESCRIPTION
### Details
- **Name:** OdeCoin
- **Symbol:** ODE
- **Description:** Utility token for the OdeCloud ecosystem — powering rewards, perks, and community engagement.
- **Address:** `EQAZx6cklgrhMUTVVtWyYz16zaW--bH6QnJo-wjJvkb-1ab9`
- **Image:** https://raw.githubusercontent.com/odecloud/odecoin-assets/main/logo.png
- **Websites:**
  - https://odecloud.com
- **Social:**
  - https://www.linkedin.com/company/odecloud
  - https://www.instagram.com/odecloud/

### Checklist
- [x] Jetton address is correct and in bounceable form
- [x] Metadata file follows the required YAML structure
- [x] All URLs are HTTPS and publicly accessible
- [x] Logo link points to a raw image file in a public repo